### PR TITLE
Add declaration for <utility> to ITree.h

### DIFF
--- a/src/ITree.h
+++ b/src/ITree.h
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <memory>
 #include <stdexcept>
+#include <utility>
 
 namespace cxxconfig {
 


### PR DESCRIPTION
I had issues getting the project to compile without `#include <utility>` being added to `ITree.h` as `std::exchange` wouldn't be defined.